### PR TITLE
rename org name to stolostron in 2.4 branch

### DIFF
--- a/.github/workflows/push-chart.yml
+++ b/.github/workflows/push-chart.yml
@@ -18,6 +18,6 @@ jobs:
         uses: peter-evans/repository-dispatch@v1.1.3
         with:
           token: ${{ secrets.HUB_REPO_TOKEN }}
-          repository: open-cluster-management/multiclusterhub-repo
+          repository: stolostron/multiclusterhub-repo
           event-type: chart-change
           client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "repository": "${{ github.repository }}"}'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ contribution. See the [DCO](DCO) file for details.
 
 Anyone may comment on issues and submit reviews for pull requests. However, in
 order to be assigned an issue or pull request, you must be a member of the
-[open-cluster-management](https://github.com/open-cluster-management) GitHub organization.
+[stolostron](https://github.com/stolostron) GitHub organization.
 
 Repo maintainers can assign you an issue or pull request by leaving a
 `/assign <your Github ID>` comment on the issue or pull request.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 HELM?=_output/linux-amd64/helm
 KUBECTL?=kubectl
 
-IMAGE=quay.io/open-cluster-management/cluster-proxy-addon:latest
+IMAGE=quay.io/stolostron/cluster-proxy-addon:latest
 IMAGE_PULL_POLICY=Always
 CLUSTER_BASE_DOMAIN=
 

--- a/stable/cluster-proxy-addon/values.yaml
+++ b/stable/cluster-proxy-addon/values.yaml
@@ -1,4 +1,4 @@
-org: open-cluster-management
+org: stolostron
 
 global:
   pullPolicy: Always


### PR DESCRIPTION
Signed-off-by: xuezhaojun <zxue@redhat.com>

This PR is very similar to https://github.com/stolostron/cluster-proxy-addon-chart/pull/17 but in a different branch.